### PR TITLE
corrected config policy fixes #8

### DIFF
--- a/scaleio/scaleio.go
+++ b/scaleio/scaleio.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	name            = "scaleio"
-	version         = 1
+	version         = 2
 	pluginType      = plugin.CollectorPluginType
 	statisticsPath  = "/api/instances/StoragePool::%s/relationships/Statistics"
 	storagePoolPath = "/api/types/StoragePool/instances"
@@ -84,7 +84,7 @@ func (s *ScaleIO) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	config.Add(r2)
 	config.Add(r3)
 	config.Add(r4)
-	cp.Add([]string{""}, config)
+	cp.Add([]string{NS_VENDOR, NS_PLUGIN}, config)
 	return cp, nil
 }
 

--- a/scaleio/scaleio_small_test.go
+++ b/scaleio/scaleio_small_test.go
@@ -64,7 +64,7 @@ func TestConfigPolicy(t *testing.T) {
 		Convey("Policy node should exist", func() {
 			So(policies, ShouldHaveLength, 1)
 		})
-		node := policies[""]
+		node := policies["intel.scaleio"]
 		rules := node.RulesAsTable()
 		Convey("All rules should exist in policy node", func() {
 			So(node.HasRules(), ShouldBeTrue)


### PR DESCRIPTION
Fixes #8 

Issue was caused by config policy demanding some values to be defined at root node, but in the task manifest they were added for specific namespace. Configuration is not required to list metrics.

Summary of changes:
- Configuration rules add on appropriate tree node 
- Bumped version to 2

How to verify it:
- Run it

Testing done:
- Manual

A picture of a snapping turtle (not required but encouraged):
- https://www.google.com/search?q=snapping+turtle&tbm=isch
